### PR TITLE
Made related sitemap urls relative.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -3,6 +3,7 @@ sax = require 'sax'
 async = require 'async'
 zlib = require 'zlib'
 domain = require 'domain'
+urlParser = require 'url'
 
 headers =
 	'user-agent': '404check.io (http://404check.io)'
@@ -10,7 +11,7 @@ agentOptions =
 	keepAlive: true
 request = request.defaults {headers, agentOptions, timeout: 60000}
 
-class sitemapParser
+class SitemapParser
 	constructor: (@url_cb, @sitemap_cb) ->
 		@visited_sitemaps = {}
 
@@ -51,18 +52,23 @@ class sitemapParser
 		@_download url, parserStream
 
 exports.parseSitemap = (url, url_cb, sitemap_cb, done) ->
-	sitemapParser = new sitemapParser url_cb, sitemap_cb
-	sitemapParser.parse url, done	
+	sitemapParser = new SitemapParser url_cb, sitemap_cb
+	sitemapParser.parse url, done
 
 exports.parseSitemaps = (urls, url_cb, done) ->
 	urls = [urls] unless urls instanceof Array
+	visited_sitemaps = []
 
-	sitemapParser = new sitemapParser url_cb, (sitemap) ->
-		queue.push sitemap
+	queue = async.queue (url, done) ->
+		sitemapParser = new SitemapParser url_cb, (sitemap) ->
+			queue.push urlParser.resolve url, sitemap
 
-	queue = async.queue sitemapParser.parse, 4
+		sitemapParser.parse url, () ->
+			Array::push.apply visited_sitemaps, Object.keys(sitemapParser.visited_sitemaps)
+			done()
+	, 4
 	queue.drain = () ->
-		done null, Object.keys(sitemapParser.visited_sitemaps)
+		done null, visited_sitemaps
 	queue.push urls
 
 exports.sitemapsInRobots = (url, cb) ->


### PR DESCRIPTION
Hey there,

Cool little library you have here!

I bumped into a problem with one sitemap, that was missing "http" in the beginning of the urls, making the library fail in loading the related sitemaps.

In this commit I made use of Node's [url.resolve](https://nodejs.org/api/url.html#url_url_resolve_from_to).

As you can see, I had to make a unique SitemapParser for each downloaded sitemap, to allow the url resolution be based on the sitemap being loaded instead of being relative to the original url. This also required me to rename the internal class to avoid name clashes. I hope that's fine.

Anyways, I hope you pull this so I can return to using your version.

Cheers,

Rolf
