### PR TITLE
Create CLI Tool; Process Relative Sitemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ node_modules
 index.js
 
 scrap.coffee
+
+yarn\.lock

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+var program = require('commander'),
+    baseurl;
+
+program
+  .arguments('<baseurl>')
+  .option('-o, --outfile <file>', 'a file to output the URL list to')
+  .option('-v, --verbose', 'output additional status info')
+  .action(function(base) {
+    var sitemaps = require('./index'),
+        fs = require('fs'), wstream;
+
+    baseurl = base;
+
+    if (program.outfile) {
+      wstream = fs.createWriteStream(program.outfile);
+    }
+
+    var urlOut = function(url) {
+      if (wstream) {
+        wstream.write(url + '\n');
+      } else {
+        console.log(url);
+      }
+    },
+    done = function(err, sitemaps) {
+      if (wstream) {
+        wstream.end();
+      }
+
+      if (err) {
+        console.error(new Error(err));
+      } else if (sitemaps && program.verbose) {
+        console.error('Parsed sitemaps: ' + sitemaps);
+      }
+    };
+
+    sitemaps.sitemapsInRobots(base + '/robots.txt', function(err, urls) {
+      if (!urls || urls.length < 1) {
+        urls = [base + '/sitemap.xml'];
+      }
+
+      sitemaps.parseSitemaps(urls, urlOut, done);
+    });
+  })
+  .parse(process.argv);
+
+if (typeof baseurl === 'undefined') {
+  program.help();
+}

--- a/index.coffee
+++ b/index.coffee
@@ -2,6 +2,7 @@ request = require 'request'
 sax = require 'sax'
 async = require 'async'
 zlib = require 'zlib'
+urlParser = require 'url'
 
 headers =
 	'user-agent': '404check.io (http://404check.io)'
@@ -36,6 +37,7 @@ class sitemapParser
 		parserStream.on 'error', (err) =>
 			done err
 		parserStream.on 'text', (text) =>
+			text = urlParser.resolve url, text
 			if inLoc
 				if isURLSet
 					@url_cb text
@@ -51,7 +53,7 @@ class sitemapParser
 
 exports.parseSitemap = (url, url_cb, sitemap_cb, done) ->
 	sitemapParser = new sitemapParser url_cb, sitemap_cb
-	sitemapParser.parse url, done	
+	sitemapParser.parse url, done
 
 exports.parseSitemaps = (urls, url_cb, done) ->
 	urls = [urls] unless urls instanceof Array

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "multiple",
     "nested"
   ],
+  "bin": {
+    "sitemap-stream-parser": "cli.js"
+  },
   "scripts": {
     "prepublish": "coffee -c index.coffee"
   },
@@ -17,6 +20,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "async": "^1.5.0",
+    "commander": "^2.11.0",
     "request": "^2.67.0",
     "sax": "^1.1.4"
   },


### PR DESCRIPTION
This PR contains not only a simple binary to process a sitemap into a URL list (it first checks for a `robots.txt` and uses any sitemaps defined there; if that doesn't produce any URLs, it checks directly for a `sitemap.xml` and processes that instead), but a simpler implementation of relative sitemap support (than that of @LuxusInc) that also resolves the actual URLs in the sitemap relative to the sitemap itself, and doesn't otherwise change the design of the overall library, either.