### PR TITLE
Use gzip insted of unzip

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -18,7 +18,7 @@ class SitemapParser
 	_download: (url, parserStream, done) ->
 
 		if url.lastIndexOf('.gz') is url.length - 3
-			unzip = zlib.createUnzip()
+			unzip = zlib.createGzip()
 			request.get({url, encoding: null}).pipe(unzip).pipe(parserStream)
 		else
 			stream = request.get({url, gzip:true})


### PR DESCRIPTION
On some sites with gzipped xml I got `decompressing: incorrect header check`. The problem was in detection type of archive. `Gzip` encoder will find it automatically.